### PR TITLE
Fjern lokal kandidatlistemock fra tester

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,12 +118,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.10</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
             <version>2.25.1</version>

--- a/src/main/kotlin/no/nav/rekrutteringsbistand/api/kandidatliste/KandidatlisteKlient.kt
+++ b/src/main/kotlin/no/nav/rekrutteringsbistand/api/kandidatliste/KandidatlisteKlient.kt
@@ -13,8 +13,10 @@ import java.net.URI
 import java.time.Duration
 
 @Component
-class KandidatlisteKlient(restTemplateBuilder: RestTemplateBuilder,
-                          externalConfiguration: ExternalConfiguration) {
+class KandidatlisteKlient(
+        restTemplateBuilder: RestTemplateBuilder,
+        externalConfiguration: ExternalConfiguration
+) {
 
     private val restTemplate: RestTemplate
     private val baseUrl: URI

--- a/src/main/kotlin/no/nav/rekrutteringsbistand/api/kandidatliste/KandidatlisteKlient.kt
+++ b/src/main/kotlin/no/nav/rekrutteringsbistand/api/kandidatliste/KandidatlisteKlient.kt
@@ -4,54 +4,41 @@ import no.nav.rekrutteringsbistand.api.stillingsinfo.Stillingsid
 import no.nav.rekrutteringsbistand.api.support.LOG
 import no.nav.rekrutteringsbistand.api.support.config.ExternalConfiguration
 import no.nav.rekrutteringsbistand.api.support.toMultiValueMap
-import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.http.*
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
-import java.time.Duration
 
 @Component
 class KandidatlisteKlient(
-        restTemplateBuilder: RestTemplateBuilder,
-        externalConfiguration: ExternalConfiguration
+        val restTemplate: RestTemplate,
+        val externalConfiguration: ExternalConfiguration
 ) {
-
-    private val restTemplate: RestTemplate
-    private val baseUrl: URI
-
-    init {
-        this.baseUrl = URI.create(externalConfiguration.kandidatlisteApi.url)
-        this.restTemplate = restTemplateBuilder
-                .setReadTimeout(Duration.ofMillis(5000))
-                .setConnectTimeout(Duration.ofMillis(2000))
-                .build()
-    }
 
     fun oppdaterKandidatliste(stillingsid: Stillingsid): ResponseEntity<Void> {
         val url = buildUpdateNotificationUrl(stillingsid)
-        LOG.info("Oppdaterer kandidatliste, url: $url")
+        LOG.info("Oppdaterer kandidatliste, stillingsid: $stillingsid")
         return try {
             restTemplate.exchange(
                     url,
                     HttpMethod.PUT,
                     HttpEntity(null, headers()),
-                    Void::class.java)
+                    Void::class.java
+            )
                     .also {
                         if (it.statusCode != HttpStatus.NO_CONTENT) {
                             LOG.warn("Uventet response fra kandidatliste-api for ad {}: {}", stillingsid.asString(), it.statusCodeValue)
                         }
                     }
         } catch (t: Throwable) {
-            LOG.error("oppdatering av kandidatliste med url $url feilet")
+            LOG.error("oppdatering av kandidatliste med stillingsid $stillingsid feilet")
             throw t
         }
-
     }
 
     private fun buildUpdateNotificationUrl(stillingsid: Stillingsid): URI {
-        return UriComponentsBuilder.fromUri(baseUrl)
+        return UriComponentsBuilder.fromUriString(externalConfiguration.kandidatlisteApi.url)
                 .pathSegment(stillingsid.asString())
                 .pathSegment("kandidatliste")
                 .build(true)

--- a/src/main/kotlin/no/nav/rekrutteringsbistand/api/stillingsinfo/StillingsinfoController.kt
+++ b/src/main/kotlin/no/nav/rekrutteringsbistand/api/stillingsinfo/StillingsinfoController.kt
@@ -31,7 +31,6 @@ class StillingsinfoController(
     }
 
     @PutMapping
-    // TODO: Kan man ikke ta inn OppdaterStillingsinfo her?
     fun oppdater(@RequestBody dto: StillingsinfoDto): ResponseEntity<StillingsinfoDto> {
         if (dto.stillingsinfoid == null) throw BadRequestException("Stillingsinfoid må ha verdi for put")
 

--- a/src/main/kotlin/no/nav/rekrutteringsbistand/api/stillingsinfo/StillingsinfoController.kt
+++ b/src/main/kotlin/no/nav/rekrutteringsbistand/api/stillingsinfo/StillingsinfoController.kt
@@ -31,6 +31,7 @@ class StillingsinfoController(
     }
 
     @PutMapping
+    // TODO: Kan man ikke ta inn OppdaterStillingsinfo her?
     fun oppdater(@RequestBody dto: StillingsinfoDto): ResponseEntity<StillingsinfoDto> {
         if (dto.stillingsinfoid == null) throw BadRequestException("Stillingsinfoid må ha verdi for put")
 

--- a/src/main/kotlin/no/nav/rekrutteringsbistand/api/support/config/AppConfig.kt
+++ b/src/main/kotlin/no/nav/rekrutteringsbistand/api/support/config/AppConfig.kt
@@ -1,26 +1,19 @@
 package no.nav.rekrutteringsbistand.api.support.config
 
 import no.nav.rekrutteringsbistand.api.support.rest.HeaderFilter
-import org.apache.http.conn.ssl.DefaultHostnameVerifier
-import org.apache.http.impl.client.HttpClientBuilder
 import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
-import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 import org.springframework.web.filter.CorsFilter
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import java.time.Duration
 
-
 @Configuration
-@EnableAsync
-class AppConfig : WebMvcConfigurer {
+class AppConfig {
 
     @Bean
     fun corsServletFilterRegistration(): FilterRegistrationBean<*> =
@@ -54,11 +47,6 @@ class AppConfig : WebMvcConfigurer {
         return RestTemplateBuilder()
                 .setConnectTimeout(Duration.ofMillis(5000))
                 .setReadTimeout(Duration.ofMillis(30000))
-                .requestFactory {
-                    HttpComponentsClientHttpRequestFactory(
-                            HttpClientBuilder.create()
-                                    .setSSLHostnameVerifier(DefaultHostnameVerifier()) // Fix SSL hostname verification for *.local domains
-                                    .build())
-                }.build()
+                .build()
     }
 }

--- a/src/main/kotlin/no/nav/rekrutteringsbistand/api/support/config/KandidatlisteMockConfig.kt
+++ b/src/main/kotlin/no/nav/rekrutteringsbistand/api/support/config/KandidatlisteMockConfig.kt
@@ -36,7 +36,5 @@ class KandidatlisteMockConfig {
                     .willReturn(WireMock.aResponse().withStatus(HttpStatus.NO_CONTENT.value())
                             .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
         }
-
-
     }
 }

--- a/src/test/kotlin/no/nav/rekrutteringsbistand/api/Testdata.kt
+++ b/src/test/kotlin/no/nav/rekrutteringsbistand/api/Testdata.kt
@@ -46,15 +46,17 @@ object Testdata {
     val enStillingsinfo = Stillingsinfo(
             stillingsinfoid = Stillingsinfoid(UUID.randomUUID()),
             eier = Eier(navident = enVeileder.navIdent, navn = enVeileder.displayName),
-            stillingsid = Stillingsid(enStilling.uuid!!))
+            stillingsid = Stillingsid(enStilling.uuid!!)
+    )
 
     val enAnnenStillingsinfo = Stillingsinfo(
             stillingsinfoid = Stillingsinfoid(UUID.randomUUID()),
             eier = Eier(navident = enVeileder.navIdent, navn = enVeileder.displayName),
-            stillingsid = Stillingsid(enAnnenStilling.uuid!!))
+            stillingsid = Stillingsid(enAnnenStilling.uuid!!)
+    )
 
     val enStillingsinfoOppdatering = OppdaterStillingsinfo(
             stillingsinfoid = enStillingsinfo.stillingsinfoid,
-            eier = Eier(navident = enAnnenVeileder.navIdent, navn = enAnnenVeileder.displayName))
-
+            eier = Eier(navident = enAnnenVeileder.navIdent, navn = enAnnenVeileder.displayName)
+    )
 }

--- a/src/test/kotlin/no/nav/rekrutteringsbistand/api/kandidatliste/KandidatlisteKlientTest.kt
+++ b/src/test/kotlin/no/nav/rekrutteringsbistand/api/kandidatliste/KandidatlisteKlientTest.kt
@@ -20,7 +20,7 @@ import org.springframework.test.context.junit4.SpringRunner
 import java.util.*
 
 @RunWith(SpringRunner::class)
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("local")
 class KandidatlisteKlientTest {
 

--- a/src/test/kotlin/no/nav/rekrutteringsbistand/api/kandidatliste/KandidatlisteKlientTest.kt
+++ b/src/test/kotlin/no/nav/rekrutteringsbistand/api/kandidatliste/KandidatlisteKlientTest.kt
@@ -1,27 +1,46 @@
 package no.nav.rekrutteringsbistand.api.kandidatliste
 
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.junit.WireMockRule
 import no.nav.rekrutteringsbistand.api.stillingsinfo.Stillingsid
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.http.HttpStatus
+import org.springframework.http.HttpHeaders.ACCEPT
+import org.springframework.http.HttpHeaders.CONTENT_TYPE
+import org.springframework.http.HttpStatus.NO_CONTENT
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 import java.util.*
 
 @RunWith(SpringRunner::class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@ActiveProfiles("local", "kandidatlisteMock")
+@SpringBootTest
+@ActiveProfiles("local")
 class KandidatlisteKlientTest {
+
+    @get:Rule
+    val wiremock = WireMockRule(WireMockConfiguration.options().port(9924))
 
     @Autowired
     lateinit var klient: KandidatlisteKlient
 
     @Test
-    fun `Skal kunne oppdatere en kandidatliste`() {
-        val response = klient.oppdaterKandidatliste(Stillingsid(UUID.randomUUID()))
-        assertThat(response.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
+    fun `oppdaterKandidatliste skal returnere no content`() {
+        wiremock.stubFor(
+                put(urlPathMatching("/pam-kandidatsok-api/rest/veileder/stilling/.*/kandidatliste"))
+                        .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON.toString()))
+                        .withHeader(ACCEPT, equalTo(APPLICATION_JSON.toString()))
+                        .willReturn(aResponse().withStatus(NO_CONTENT.value())
+                                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+        )
+
+        val respons = klient.oppdaterKandidatliste(Stillingsid(UUID.randomUUID()))
+        assertThat(respons.statusCode).isEqualTo(NO_CONTENT)
     }
 }

--- a/src/test/kotlin/no/nav/rekrutteringsbistand/api/kandidatliste/KandidatlisteKlientTest.kt
+++ b/src/test/kotlin/no/nav/rekrutteringsbistand/api/kandidatliste/KandidatlisteKlientTest.kt
@@ -10,8 +10,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.http.HttpHeaders.ACCEPT
-import org.springframework.http.HttpHeaders.CONTENT_TYPE
+import org.springframework.http.HttpHeaders.*
 import org.springframework.http.HttpStatus.NO_CONTENT
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
@@ -37,6 +36,7 @@ class KandidatlisteKlientTest {
                         .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON.toString()))
                         .withHeader(ACCEPT, equalTo(APPLICATION_JSON.toString()))
                         .willReturn(aResponse().withStatus(NO_CONTENT.value())
+                                .withHeader(CONNECTION, "close") // https://stackoverflow.com/questions/55624675/how-to-fix-nohttpresponseexception-when-running-wiremock-on-jenkins
                                 .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE))
         )
 

--- a/src/test/kotlin/no/nav/rekrutteringsbistand/api/kandidatliste/KandidatlisteKlientTest.kt
+++ b/src/test/kotlin/no/nav/rekrutteringsbistand/api/kandidatliste/KandidatlisteKlientTest.kt
@@ -30,7 +30,7 @@ class KandidatlisteKlientTest {
     lateinit var klient: KandidatlisteKlient
 
     @Test
-    fun `oppdaterKandidatliste skal returnere no content`() {
+    fun `Skal sende oppdaterKandidatliste-request med riktig URL og headere`() {
         wiremock.stubFor(
                 put(urlPathMatching("/pam-kandidatsok-api/rest/veileder/stilling/.*/kandidatliste"))
                         .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON.toString()))

--- a/src/test/kotlin/no/nav/rekrutteringsbistand/api/stilling/StillingComponentTest.kt
+++ b/src/test/kotlin/no/nav/rekrutteringsbistand/api/stilling/StillingComponentTest.kt
@@ -119,6 +119,7 @@ internal class StillingComponentTest {
                         .withHeader(ACCEPT, equalTo(APPLICATION_JSON.toString()))
                         .withHeader(AUTHORIZATION, matching("Bearer .*}"))
                         .willReturn(aResponse().withStatus(200)
+                                .withHeader(CONNECTION, "close") // https://stackoverflow.com/questions/55624675/how-to-fix-nohttpresponseexception-when-running-wiremock-on-jenkins
                                 .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
                                 .withBody(objectMapper.writeValueAsString(body)))
         )
@@ -130,6 +131,7 @@ internal class StillingComponentTest {
                         .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON.toString()))
                         .withHeader(ACCEPT, equalTo(APPLICATION_JSON.toString()))
                         .willReturn(aResponse().withStatus(200)
+                                .withHeader(CONNECTION, "close") // https://stackoverflow.com/questions/55624675/how-to-fix-nohttpresponseexception-when-running-wiremock-on-jenkins
                                 .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
                                 .withBody(objectMapper.writeValueAsString(body)))
         )
@@ -142,6 +144,7 @@ internal class StillingComponentTest {
                         .withHeader(ACCEPT, equalTo(APPLICATION_JSON.toString()))
                         .withHeader(AUTHORIZATION, matching("Bearer .*}"))
                         .willReturn(aResponse().withStatus(200)
+                                .withHeader(CONNECTION, "close") // https://stackoverflow.com/questions/55624675/how-to-fix-nohttpresponseexception-when-running-wiremock-on-jenkins
                                 .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
                                 .withBody(body))
         )

--- a/src/test/kotlin/no/nav/rekrutteringsbistand/api/stillingsinfo/StillingsinfoComponentTest.kt
+++ b/src/test/kotlin/no/nav/rekrutteringsbistand/api/stillingsinfo/StillingsinfoComponentTest.kt
@@ -1,13 +1,16 @@
 package no.nav.rekrutteringsbistand.api.stillingsinfo
 
 import arrow.core.getOrElse
-import no.nav.rekrutteringsbistand.api.Testdata
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.junit.WireMockRule
 import no.nav.rekrutteringsbistand.api.Testdata.enStillingsinfo
 import no.nav.rekrutteringsbistand.api.support.toMultiValueMap
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.runner.RunWith
@@ -22,7 +25,9 @@ import org.springframework.http.HttpHeaders.ACCEPT
 import org.springframework.http.HttpHeaders.CONTENT_TYPE
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.NO_CONTENT
 import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 import java.util.*
@@ -31,6 +36,9 @@ import java.util.*
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("local")
 class StillingsinfoComponentTest {
+
+    @get:Rule
+    val wiremock = WireMockRule(WireMockConfiguration.options().port(9924))
 
     @LocalServerPort
     private var port = 0
@@ -74,44 +82,28 @@ class StillingsinfoComponentTest {
 
 
     @Test
-    fun `lagring av rekrutteringsbistand skal returnere HTTP status 201 og JSON med nyopprettet rekrutteringUuid`() {
-        // Given
-        val tilLagring = Testdata.enStillingsinfo.asDto().copy(stillingsinfoid = null)
+    fun `Opprettelse av stillingsinfo skal returnere HTTP 201 med opprettet stillingsinfo`() {
+        val tilLagring = enStillingsinfo.asDto().copy(stillingsinfoid = null)
+        mockKandidatlisteOppdatering()
+
         val url = "$localBaseUrl/rekruttering"
+        val stillingsinfoRespons = restTemplate.postForEntity(url, httpEntity(tilLagring), StillingsinfoDto::class.java)
+        val lagretStillingsinfo = repository.hentForStilling(enStillingsinfo.stillingsid).getOrElse { fail("fant ikke stillingen") }
 
-        val headers = mapOf(
-                CONTENT_TYPE to APPLICATION_JSON.toString(),
-                ACCEPT to APPLICATION_JSON.toString()
-        ).toMultiValueMap()
-        val httpEntity = HttpEntity(tilLagring, headers)
-
-        // When
-        val actualResponse = restTemplate.postForEntity(url, httpEntity, StillingsinfoDto::class.java)
-
-        // Then
-        assertThat(actualResponse.statusCode).isEqualTo(HttpStatus.CREATED)
-        assertThat(actualResponse.hasBody())
-        actualResponse.body!!.apply {
-            assertThat(stillingsinfoid).isNotBlank()
-            assertDoesNotThrow { UUID.fromString(stillingsinfoid) }
-            assertThat(this.copy(stillingsinfoid = null))
-                    .isEqualTo(tilLagring)
+        assertThat(stillingsinfoRespons.statusCode).isEqualTo(HttpStatus.CREATED)
+        stillingsinfoRespons.body!!.apply {
+            assertThat(this).isEqualToIgnoringGivenFields(tilLagring, "stillingsinfoid")
+            assertThat(stillingsinfoid).isEqualTo(lagretStillingsinfo.stillingsinfoid.asString())
         }
 
-        val oppdatert = repository.hentForStilling(Testdata.enStillingsinfo.stillingsid).getOrElse { fail("fant ikke stillingen") }
-        oppdatert.apply {
-            assertThat(stillingsinfoid.asString()).isNotBlank()
-            assertThat(this.asDto())
-                    .isEqualTo(actualResponse.body!!)
-            repository.slett(this.stillingsinfoid)
-        }
+        repository.slett(lagretStillingsinfo.stillingsinfoid)
     }
 
     @Test
     fun `oppdatering av rekrutteringsbistand skal returnere HTTP status 200 og JSON med oppdatert rekrutteringUuid`() {
 
         // Given
-        val lagre = Testdata.enStillingsinfo
+        val lagre = enStillingsinfo
         val oppdatere = lagre.copy(eier = Eier(navident = "endretIdent", navn = "endretNavn"))
         val lagret = repository.lagre(lagre)
 
@@ -156,5 +148,15 @@ class StillingsinfoComponentTest {
                 ACCEPT to APPLICATION_JSON.toString()
         ).toMultiValueMap()
         return HttpEntity(body, headers)
+    }
+
+    private fun mockKandidatlisteOppdatering() {
+        wiremock.stubFor(
+                put(urlPathMatching("/pam-kandidatsok-api/rest/veileder/stilling/.*/kandidatliste"))
+                        .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON.toString()))
+                        .withHeader(ACCEPT, equalTo(APPLICATION_JSON.toString()))
+                        .willReturn(aResponse().withStatus(NO_CONTENT.value())
+                                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE))
+        )
     }
 }

--- a/src/test/kotlin/no/nav/rekrutteringsbistand/api/stillingsinfo/StillingsinfoComponentTest.kt
+++ b/src/test/kotlin/no/nav/rekrutteringsbistand/api/stillingsinfo/StillingsinfoComponentTest.kt
@@ -59,35 +59,16 @@ class StillingsinfoComponentTest {
     }
 
     @Test
-    fun `henting av rekrutteringsbistand basert på bruker skal returnere HTTP status 200 og JSON med nyopprettet rekrutteringUuid`() {
-        // Given
-        val lagre = Testdata.enStillingsinfo
-        repository.lagre(lagre)
+    fun `Henting av stillingsinfo basert på bruker skal returnere HTTP 200 med lagret stillingsinfo`() {
+        repository.lagre(enStillingsinfo)
 
-        val url = "$localBaseUrl/rekruttering/ident/${lagre.eier.navident}"
+        val url = "$localBaseUrl/rekruttering/ident/${enStillingsinfo.eier.navident}"
+        val stillingsinfoRespons = restTemplate.exchange(url, HttpMethod.GET, httpEntity(null), object : ParameterizedTypeReference<List<StillingsinfoDto>>() {})
 
-        val headers = mapOf(
-                CONTENT_TYPE to APPLICATION_JSON.toString(),
-                ACCEPT to APPLICATION_JSON.toString()
-        ).toMultiValueMap()
-
-        val httpEntity = HttpEntity(null, headers)
-
-        // When
-        val actualResponse =
-                restTemplate.run { exchange(url, HttpMethod.GET, httpEntity, object : ParameterizedTypeReference<List<StillingsinfoDto>>() {}) }
-
-        // Then
-        assertThat(actualResponse.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(actualResponse.hasBody())
-        actualResponse.body!!.apply {
+        assertThat(stillingsinfoRespons.statusCode).isEqualTo(HttpStatus.OK)
+        stillingsinfoRespons.body.apply {
             assertThat(this).hasSize(1)
-            this.get(0).apply {
-                assertThat(stillingsinfoid).isNotBlank()
-                assertDoesNotThrow { UUID.fromString(stillingsinfoid) }
-                assertThat(this).isEqualTo(lagre.asDto())
-                repository.slett(lagre.stillingsinfoid)
-            }
+            assertThat(this!![0]).isEqualTo(enStillingsinfo.asDto())
         }
     }
 

--- a/src/test/kotlin/no/nav/rekrutteringsbistand/api/stillingsinfo/StillingsinfoComponentTest.kt
+++ b/src/test/kotlin/no/nav/rekrutteringsbistand/api/stillingsinfo/StillingsinfoComponentTest.kt
@@ -30,7 +30,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 
 @RunWith(SpringRunner::class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("local")
 class StillingsinfoComponentTest {
 

--- a/src/test/kotlin/no/nav/rekrutteringsbistand/api/stillingsinfo/StillingsinfoRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/rekrutteringsbistand/api/stillingsinfo/StillingsinfoRepositoryTest.kt
@@ -15,7 +15,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 
 @RunWith(SpringRunner::class)
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("local")
 class StillingsinfoRepositoryTest {
 


### PR DESCRIPTION
- Splitter opp kandidatlistemock som kjøres når man starter appen lokalt og mocken som er i testene
- Har også prøvd å fornkle testene litt. Sjekk gjerne at jeg har forstått de orginale testene riktig og at vi fortsatt tester det som trengs.