### PR TITLE
Muliggjøre rollback ved å rekjøre CircleCI-bygg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
       - checkout
       - run:
           name: Deploy til << parameters.cluster >>
-          command: deployment-cli deploy create --cluster=<< parameters.cluster >> --repository=navikt/rekrutteringsbistand-api --team=teamtag --resource=<< parameters.nais-yaml >> --version=$CIRCLE_SHA1 --ref=$CIRCLE_BRANCH
+          command: deployment-cli deploy create --cluster=<< parameters.cluster >> --repository=navikt/rekrutteringsbistand-api --team=teamtag --resource=<< parameters.nais-yaml >> --version=$CIRCLE_SHA1 --ref=$CIRCLE_SHA1
 
 workflows:
   version: 2.1


### PR DESCRIPTION
Feil i prodversjon kan vanligvis fikses bed å deploye en ny versjon som inneholder en fiks. Det kan være kjekt å ha muligheten til å rulle tilbake istedenfor, for de tilfellene vhor det vil ta tid å komm eopp med fiksen. En enkel måte å gjøre rollback på er å rekjøre et gammel bygg i CircleCI. For at dette skal funke må argumentet "ref" til deployment-cli være $CIRCLE_SHA1. Da er bygget koblet til den committen som utløste bygget en gang i tiden. I motsetning, hvis ref peker på en branch, vil det nyeste committen i branchen blir brukt. Da vil rekjøring føre til at vi deployer en nyere versjon av koden enn ved første gangs kjøring, altså vi får ikke redeploy og ikke rollback.