### PR TITLE
Fiks kopiering av stilling. Fjern feilsøking

### DIFF
--- a/src/main/kotlin/no/nav/rekrutteringsbistand/api/stilling/StillingController.kt
+++ b/src/main/kotlin/no/nav/rekrutteringsbistand/api/stilling/StillingController.kt
@@ -1,6 +1,5 @@
 package no.nav.rekrutteringsbistand.api.stilling
 
-import no.nav.rekrutteringsbistand.api.support.LOG
 import no.nav.rekrutteringsbistand.api.support.config.Configuration
 import no.nav.rekrutteringsbistand.api.support.config.ExternalConfiguration
 import no.nav.rekrutteringsbistand.api.support.rest.RestProxy
@@ -21,7 +20,7 @@ class StillingController(
         val stillingService: StillingService
 ) {
 
-    @PostMapping("/rekrutteringsbistand/api/v1/ads/")
+    @PostMapping("/rekrutteringsbistand/api/v1/ads")
     fun proxyPostTilStillingsApi(request: HttpServletRequest, @RequestBody stilling: Stilling): ResponseEntity<StillingMedStillingsinfo> {
         return ResponseEntity.ok().body(stillingService.opprettStilling(stilling, request.queryString))
     }
@@ -33,8 +32,6 @@ class StillingController(
 
     @RequestMapping("/rekrutteringsbistand/api/v1/**")
     fun proxyGetTilStillingsApi(method: HttpMethod, request: HttpServletRequest, @RequestBody(required = false) body: String?): ResponseEntity<String> {
-        LOG.debug("Treffer 'proxyGetTilStillingsApi' med URL ${request.requestURL} og HTTP-metode ${method.name} med body-lengde ${body?.length ?: 0}");
-
         return restProxy.proxyJsonRequest(method, request, Configuration.ROOT_URL, body
                 ?: "", externalConfiguration.stillingApi.url)
     }


### PR DESCRIPTION
I frontend har vi følgende POST-kall:

```
const postUrl = `${AD_API}ads?classify=true`;
```

Denne kjøres to ganger.
1) Når man trykker "Opprett stilling" fra mine stillinger og det lages en "placeholder"-stilling
2) Når man kopierer en stilling i "mine stillinger"-listen

Disse kallene vil treffe `proxyGetTilStillingsApi` her i backend, i stedet for den riktige metoden `proxyPostTilStillingsApi`, fordi kallet ikke har noen slash på slutten. Dette har gått fint ved opprettelse av stilling fordi det ikke ligger noe`rekruttering`-field på objektet, men ved kopiering kommer dette feltet med og blir sendt videre til `pam-ad-api`, hvor det resulterer i en `400 Bad Request`.

Fjernet slash slik at POST-kallene fra frontend treffer riktig metode i backend.