### PR TITLE
Eksplisitt endepunkt delete stilling

### DIFF
--- a/src/main/kotlin/no/nav/rekrutteringsbistand/api/stilling/StillingController.kt
+++ b/src/main/kotlin/no/nav/rekrutteringsbistand/api/stilling/StillingController.kt
@@ -42,7 +42,7 @@ class StillingController(
 
     @RequestMapping("/rekrutteringsbistand/api/v1/**")
     fun proxyGetTilStillingsApi(method: HttpMethod, request: HttpServletRequest, @RequestBody(required = false) body: String?): ResponseEntity<String> {
-        LOG.debug("Deprecated: Mottok $method til '/search-api/**' (${request.requestURI})")
+        LOG.debug("Deprecated: Mottok $method til '/rekrutteringsbistand/api/v1/**' (${request.requestURI})")
         val respons = restProxy.proxyJsonRequest(method, request, replaceInUrl, body
                 ?: "", externalConfiguration.stillingApi.url)
         val responsBody: String = respons.body ?: ""

--- a/src/main/kotlin/no/nav/rekrutteringsbistand/api/stilling/StillingController.kt
+++ b/src/main/kotlin/no/nav/rekrutteringsbistand/api/stilling/StillingController.kt
@@ -6,8 +6,7 @@ import no.nav.rekrutteringsbistand.api.support.rest.RestProxy
 import no.nav.security.oidc.api.Protected
 import no.nav.security.oidc.api.Unprotected
 import org.springframework.http.HttpMethod
-import org.springframework.http.HttpMethod.GET
-import org.springframework.http.HttpMethod.POST
+import org.springframework.http.HttpMethod.*
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.net.URLDecoder
@@ -34,8 +33,16 @@ class StillingController(
         return ResponseEntity.ok().body(stillingService.oppdaterStilling(uuid, stilling, request.queryString))
     }
 
+    @DeleteMapping("/rekrutteringsbistand/api/v1/ads")
+    fun proxyDeleteTilStillingsApi(request: HttpServletRequest): ResponseEntity<String> {
+        LOG.debug("Mottok ${request.method} til ${request.requestURI}")
+        val respons = restProxy.proxyJsonRequest(DELETE, request, replaceInUrl, null, externalConfiguration.stillingApi.url)
+        return ResponseEntity(respons.body, respons.statusCode)
+    }
+
     @RequestMapping("/rekrutteringsbistand/api/v1/**")
     fun proxyGetTilStillingsApi(method: HttpMethod, request: HttpServletRequest, @RequestBody(required = false) body: String?): ResponseEntity<String> {
+        LOG.debug("Deprecated: Mottok $method til '/search-api/**' (${request.requestURI})")
         val respons = restProxy.proxyJsonRequest(method, request, replaceInUrl, body
                 ?: "", externalConfiguration.stillingApi.url)
         val responsBody: String = respons.body ?: ""

--- a/src/main/kotlin/no/nav/rekrutteringsbistand/api/stilling/StillingController.kt
+++ b/src/main/kotlin/no/nav/rekrutteringsbistand/api/stilling/StillingController.kt
@@ -1,18 +1,19 @@
 package no.nav.rekrutteringsbistand.api.stilling
 
 import no.nav.rekrutteringsbistand.api.support.LOG
-import no.nav.rekrutteringsbistand.api.support.config.Configuration
 import no.nav.rekrutteringsbistand.api.support.config.ExternalConfiguration
 import no.nav.rekrutteringsbistand.api.support.rest.RestProxy
 import no.nav.security.oidc.api.Protected
 import no.nav.security.oidc.api.Unprotected
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpMethod.GET
 import org.springframework.http.HttpMethod.POST
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import javax.servlet.http.HttpServletRequest
+
 
 @RestController
 @Protected
@@ -21,6 +22,7 @@ class StillingController(
         val externalConfiguration: ExternalConfiguration,
         val stillingService: StillingService
 ) {
+
 
     @PostMapping("/rekrutteringsbistand/api/v1/ads")
     fun proxyPostTilStillingsApi(request: HttpServletRequest, @RequestBody stilling: Stilling): ResponseEntity<StillingMedStillingsinfo> {
@@ -34,25 +36,33 @@ class StillingController(
 
     @RequestMapping("/rekrutteringsbistand/api/v1/**")
     fun proxyGetTilStillingsApi(method: HttpMethod, request: HttpServletRequest, @RequestBody(required = false) body: String?): ResponseEntity<String> {
-        val respons = restProxy.proxyJsonRequest(method, request, Configuration.ROOT_URL, body
+        val respons = restProxy.proxyJsonRequest(method, request, replaceInUrl, body
                 ?: "", externalConfiguration.stillingApi.url)
         val responsBody: String = respons.body ?: ""
         return ResponseEntity(responsBody, respons.statusCode)
     }
 
     @RequestMapping("/search-api/**")
+    @Deprecated("Skal erstattes av mer eksplisitte/spesifikke endepunktmetoder")
     private fun proxySokTilStillingsApi(method: HttpMethod, request: HttpServletRequest, @RequestBody requestBody: String?): ResponseEntity<String> {
-        LOG.debug("Mottok $method til '/search-api/**' (${request.requestURI})")
-        val respons = restProxy.proxyJsonRequest(method, request, Configuration.ROOT_URL, requestBody
+        LOG.debug("Deprecated: Mottok $method til '/search-api/**' (${request.requestURI})")
+        val respons = restProxy.proxyJsonRequest(method, request, replaceInUrl, requestBody
                 ?: "", externalConfiguration.stillingApi.url) // TODO Are ""?
         val responsBody: String = respons.body ?: ""
         return ResponseEntity(responsBody, respons.statusCode)
     }
 
+    @GetMapping("/search-api/underenhet/_search")
+    private fun getSokTilPamAdApi(request: HttpServletRequest): ResponseEntity<String> {
+        LOG.debug("Mottok ${request.method} til ${request.requestURI}")
+        val respons = restProxy.proxyJsonRequest(GET, request, replaceInUrl, null, externalConfiguration.stillingApi.url)
+        return ResponseEntity(respons.body, respons.statusCode)
+    }
+
     @PostMapping("/search-api/underenhet/_search")
     private fun postSokTilPamAdApi(request: HttpServletRequest, @RequestBody requestBody: String): ResponseEntity<String> {
         LOG.debug("Mottok ${request.method} til ${request.requestURI}")
-        val respons = restProxy.proxyJsonRequest(POST, request, Configuration.ROOT_URL, requestBody, externalConfiguration.stillingApi.url)
+        val respons = restProxy.proxyJsonRequest(POST, request, replaceInUrl, requestBody, externalConfiguration.stillingApi.url)
         return ResponseEntity(respons.body, respons.statusCode)
     }
 
@@ -80,3 +90,4 @@ class StillingController(
 
 }
 
+private const val replaceInUrl = "/rekrutteringsbistand-api"

--- a/src/main/kotlin/no/nav/rekrutteringsbistand/api/support/config/Configuration.kt
+++ b/src/main/kotlin/no/nav/rekrutteringsbistand/api/support/config/Configuration.kt
@@ -1,7 +1,0 @@
-package no.nav.rekrutteringsbistand.api.support.config
-
-class Configuration {
-    companion object {
-        const val ROOT_URL = "/rekrutteringsbistand-api"
-    }
-}

--- a/src/main/kotlin/no/nav/rekrutteringsbistand/api/support/rest/RestProxy.kt
+++ b/src/main/kotlin/no/nav/rekrutteringsbistand/api/support/rest/RestProxy.kt
@@ -24,7 +24,7 @@ class RestProxy(val restTemplate: RestTemplate, val tokenUtils: TokenUtils) {
     fun proxyJsonRequest(method: HttpMethod,
                          request: HttpServletRequest,
                          stripPathPrefix: String,
-                         body: String,
+                         body: String?,
                          targetUrl: String): ResponseEntity<String> {
         val url = buildProxyTargetUrl(request, stripPathPrefix, targetUrl)
         LOG.debug("Proxy til URL=$url, HTTP-metode=$method")


### PR DESCRIPTION
Fjerner request body fordi https://tools.ietf.org/html/rfc7231#section-4 sier
>    A payload within a DELETE request message has no defined semantics;
>    sending a payload body on a DELETE request might cause some existing
>    implementations to reject the request.