### PR TITLE
Mer kontekst i logging av forbidden respons + fiks deprecation warnings

### DIFF
--- a/src/main/kotlin/no/nav/rekrutteringsbistand/api/support/rest/RestResponseEntityExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/rekrutteringsbistand/api/support/rest/RestResponseEntityExceptionHandler.kt
@@ -1,5 +1,6 @@
 package no.nav.rekrutteringsbistand.api.support.rest
 
+import jakarta.servlet.http.HttpServletRequest
 import no.nav.rekrutteringsbistand.api.support.log
 import no.nav.security.token.support.core.exceptions.JwtTokenValidatorException
 import org.springframework.dao.EmptyResultDataAccessException
@@ -11,7 +12,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
-import jakarta.servlet.http.HttpServletRequest
 
 @ControllerAdvice
 class RestResponseEntityExceptionHandler : ResponseEntityExceptionHandler() {
@@ -28,7 +28,7 @@ class RestResponseEntityExceptionHandler : ResponseEntityExceptionHandler() {
     @Deprecated("Bruk arrow.core.Option eller en tom collection istedenfor. Exceptions for kontrollflyt som ikke er feilsituasjoner er et anti-pattern.")
     protected fun handleNoContent(e: RuntimeException, request: HttpServletRequest): ResponseEntity<Any> {
         val uri = request.requestURI
-        log.info("No content found at requestURI=${request.requestURI}, HTTP method=${request.method}")
+        log.info("No content found at requestURI=${request.requestURI}, HTTP method=${request.method}", e)
         return ResponseEntity.status(NO_CONTENT).body(uri)
     }
 
@@ -39,12 +39,12 @@ class RestResponseEntityExceptionHandler : ResponseEntityExceptionHandler() {
     protected fun handleExceptionFraRestTemplate(
         e: RestClientResponseException, request: HttpServletRequest
     ): ResponseEntity<String> {
-        val msg = "Mottok HTTP respons ${e.rawStatusCode} fra ${request.method} mot URL ${request.requestURL}"
-        when (e.rawStatusCode) {
+        val msg = "Mottok HTTP respons ${e.statusCode} fra ${request.method} mot URL ${request.requestURL}"
+        when (e.statusCode.value()) {
             403 -> log.warn(msg, e)
             404 -> log.info(msg, e)
             else -> log.error(msg, e)
         }
-        return ResponseEntity.status(e.rawStatusCode).body(e.responseBodyAsString)
+        return ResponseEntity.status(e.statusCode.value()).body(e.responseBodyAsString)
     }
 }


### PR DESCRIPTION
Hmm, kan jeg logge hvem som er pålogget veileder? Det er persondata. Bør vel logges til Securelogs i så fall... Jeg trenger en god grunn til denne endringen for å rettferdiggjøre tidsbruken, så kanskje jeg bare skal droppe dette.